### PR TITLE
test/1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "jest": "^28.1.0",
     "nodemon": "^2.0.16"
   },
-  "scripts": {},
+  "scripts": {
+    "start": "nodemon ./src/app.js"
+  },
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
a causa do problema,
A ausência do script 'start' no arquivo package.json estava impedindo a execução da aplicação.

o porquê a alteração foi feita daquela maneira
Porque utilizamos o script 'start' para iniciar esse servidor Web Node.js conforme indicado no log de erro. A inclusão do 'nodemon' assegura a atualização automática da aplicação durante a execução.

como ela soluciona o problema encontrado.
Ao subir o Docker, é esperado que exista o script "start" para que possamos iniciar a aplicação, como pode ser visto no arquivo 'Dockerfile.dev'.