### PR TITLE
test/2

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,8 +10,13 @@ const port = Number(process.env.PORT || 8089)
 const app = express();
 
 const whitelist = [
-  // TODO whitelist
+  'localhost:8081'
 ]
+
+app.use(function (req, _res, next) {
+  req.headers.origin = req.headers.origin || req.headers.host;
+  next();
+})
 
 app.use(cors({
   origin: function (origin, callback) {


### PR DESCRIPTION
a causa do problema,
A política de segurança do CORS bloqueava as solicitações devido à falta do cabeçalho 'origin'.

o porquê a alteração foi feita daquela maneira
A alteração foi feita adicionando 'localhost:8081' à whitelist e ajustando o middleware para definir o host como origin caso não esteja presente.

como ela soluciona o problema encontrado.
Isso resolve o problema ao permitir solicitações de 'localhost:8081' e garantir a presença do cabeçalho 'origin' para cumprir as políticas de CORS.