### PR TITLE
test/3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - main:/var/lib/mysql
       - ./db/:/docker-entrypoint-initdb.d/
     ports:
-      - 3305:3305
+      - 3306:3306
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 1s
@@ -36,7 +36,7 @@ services:
     environment:
       WRITER_MYSQL_HOST: "mysql"
       WRITER_MYSQL_PASS: "root"
-      WRITER_MYSQL_PORT: "3305"
+      WRITER_MYSQL_PORT: "3306"
       WRITER_MYSQL_USER: "root"
       NODE_ENV: "development"
       PORT: "8081"


### PR DESCRIPTION
a causa do problema,
A porta do MySQL no docker-compose estava configurada para 3305.

o porquê a alteração foi feita daquela maneira
A porta do MySQL foi ajustada para a padrão (3306) para alinhar com a configuração convencional do MySQL, evitando que a conexão seja recusada.

como ela soluciona o problema encontrado.
A modificação da porta do MySQL para 3306 resolve a inconsistência, assegurando que a aplicação possa se conectar corretamente ao serviço MySQL no contêiner.