### PR TITLE
test/4

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE posts (
 );
 
 CREATE TABLE users (
-    id VARCHAR(100) PRIMARY KEY AUTO_INCREMENT,
+    id INT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(100),
     user_email VARCHAR(100) NOT NULL,
     user_password VARCHAR(200) NOT NULL


### PR DESCRIPTION
a causa do problema,
O erro ocorreu porque o tipo de dado do campo 'id' na tabela User no MySQL estava configurado como VARCHAR(100) ao invés de INT.

o porquê a alteração foi feita daquela maneira
A modificação foi feita para alinhar o tipo de dado do campo 'id' na tabela User com a definição correta, uma vez que se trata de uma coluna auto incrementada.

como ela soluciona o problema encontrado.
A correção no esquema da tabela User, ajustando o tipo de dado do campo 'id' para INT, resolve a inconsistência e permite que a aplicação se conecte corretamente ao MySQL.