### PR TITLE
test/5

### DIFF
--- a/src/modules/common/handlers/knex/knex.js
+++ b/src/modules/common/handlers/knex/knex.js
@@ -22,7 +22,7 @@ const getTransaction = async () => {
     return {transaction};
 }
 
-const commitTransaction = ({ transaction }) => transaction.rollback();
+const commitTransaction = ({ transaction }) => transaction.commit();
 
 const rollbackTransaction = ({ transaction }) => transaction.rollback();
 


### PR DESCRIPTION
a causa do problema,
O problema ocorreu devido a um erro na função commitTransaction, onde transaction.rollback() estava sendo utilizado em vez de transaction.commit().

o porquê a alteração foi feita daquela maneira
A modificação foi feita para corrigir a lógica da função commitTransaction e utilizar transaction.commit(), que é a ação correta para confirmar uma transação no Knex.

como ela soluciona o problema encontrado.
A correção na função commitTransaction garante que as transações sejam confirmadas corretamente, evitando problemas de rollback indevido e mantendo a integridade das operações no banco de dados.