### PR TITLE
test/6

### DIFF
--- a/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
+++ b/src/modules/repositories/User/createUsersRepositories/createUsersRepositories.js
@@ -11,9 +11,7 @@ const createUserRepositories = async ({
     const { transaction } = await getTransaction();
 
     try {
-        const {
-            user_created
-        } = await transaction('users').insert(user)
+        const user_created = await transaction('users').insert(user)
         
         const has_response = Array.isArray(user_created) && user_created.length > 0;
 


### PR DESCRIPTION
a causa do problema,
O problema decorreu de uma desestruturação inadequada na função createUserRepositories, onde se tentou desestruturar um resultado de uma inserção no banco de dados.

o porquê a alteração foi feita daquela maneira
A modificação foi realizada para corrigir essa desestruturação inadequada, armazenando o resultado na variável `user_created`.

como ela soluciona o problema encontrado.
A  remoção da desestruturação permite que a função retorne o `id` do novo usuário ao invés de `undefined`.