### PR TITLE
test/10

### DIFF
--- a/src/modules/repositories/User/updateUserRepositories/updateUserRepositories.js
+++ b/src/modules/repositories/User/updateUserRepositories/updateUserRepositories.js
@@ -18,7 +18,7 @@ const updateUserRepositories = async ({
             user_email,
             user_password,
             full_name
-        })
+        }).where({id});
 
         await commitTransaction({ transaction })
 


### PR DESCRIPTION
1. A causa do problema:
A operação de atualização (`PUT`) em /user não estava utilizando uma cláusula `WHERE`, resultando na atualização de todas as entradas na tabela.

2. O porquê a alteração foi feita daquela maneira:
A cláusula`WHERE` foi adicionada para garantir que a operação de atualização afete apenas o usuário específico identificado pelo `id`.

3. Como ela soluciona o problema encontrado:
Agora, a operação `PUT` /user utiliza uma cláusula `WHERE`, garantindo que a atualização seja aplicada apenas ao usuário com o `id` especificado, corrigindo o problema de atualização global.