### PR TITLE
test/13

### DIFF
--- a/src/modules/handlers/Posts/listPost.js
+++ b/src/modules/handlers/Posts/listPost.js
@@ -3,7 +3,8 @@
 const httpStatusCodes = require('http-status-codes');
 const { httpErrorHandler } = require('../../common/handlers');
 const { 
-    getPostByUserIdService 
+    getPostByUserIdService,
+    getAllPostsService 
 } = require('../../services');
 
 const listPostHandler = async (req, res, next) => {
@@ -12,11 +13,16 @@ const listPostHandler = async (req, res, next) => {
             user_id
         } = req.query;
         
-        const {
-            posts
-        } = await getPostByUserIdService({
-            user_id
-        })
+        const has_user_id = !!user_id && Number.isFinite(+user_id);
+        
+        const user_posts = has_user_id && await getPostByUserIdService({user_id});
+
+        const all_posts = !has_user_id && await getAllPostsService();
+
+        const posts = [
+            ...user_posts ? user_posts.posts : [],
+            ...all_posts ? all_posts.posts : [],
+        ];
 
         return res.status(httpStatusCodes.OK).send({posts});
     }catch(error){

--- a/src/modules/repositories/Post/getAllPostsRepositories/getAllPostsRepositories.js
+++ b/src/modules/repositories/Post/getAllPostsRepositories/getAllPostsRepositories.js
@@ -1,12 +1,10 @@
-const { 
+const {
     client
 } = require('../../../common/handlers')
 
-const getPostByUserIdRepositories = async ({
-    user_id
-} = {}) => {
+const getAllPostsRepositories = async () => {
 
-    const response = await client('posts').where({author_id: user_id})
+    const response = await client('posts')
 
     const has_response = Array.isArray(response) && response.length > 0;
 
@@ -22,5 +20,5 @@ const getPostByUserIdRepositories = async ({
 }
 
 module.exports = {
-    getPostByUserIdRepositories
+    getAllPostsRepositories
 }

--- a/src/modules/repositories/index.js
+++ b/src/modules/repositories/index.js
@@ -6,6 +6,7 @@ module.exports = Object.freeze({
     ...require('./User/updateUserRepositories/updateUserRepositories'),
     ...require('./Post/createPostRepositories/createPostRepositories'),
     ...require('./Post/deletePostRepositories/deletePostRepositories'),
+    ...require('./Post/getAllPostsRepositories/getAllPostsRepositories'),
     ...require('./Post/getPostByPostIdRepositories/getPostByPostIdRepositories'),
     ...require('./Post/getPostByUserIdRepositories/getPostByUserIdRepositories'),
     ...require('./Post/updatePostRepositories/updatePostRepositories')

--- a/src/modules/services/Post/listAllPostsService/listAllPostsService.js
+++ b/src/modules/services/Post/listAllPostsService/listAllPostsService.js
@@ -1,0 +1,19 @@
+const { getAllPostsRepositories } = require("../../../repositories");
+
+const getAllPostsService = async () => {
+
+    const {
+        posts = []
+    } = await getAllPostsRepositories();
+
+    const has_multiple_posts = Array.isArray(posts) && posts.length > 0;
+
+    return {
+        posts,
+        has_multiple_posts
+    };
+}
+
+module.exports = {
+    getAllPostsService
+}

--- a/src/modules/services/Post/listPostService/listPostService.js
+++ b/src/modules/services/Post/listPostService/listPostService.js
@@ -17,7 +17,7 @@ const getPostByUserIdService = async ({
         throw new Error("Missing author in database")
     }
 
-    const posts = await getPostByUserIdRepositories({user_id});
+    const { posts } = await getPostByUserIdRepositories({user_id});
 
     return {
         posts

--- a/src/modules/services/index.js
+++ b/src/modules/services/index.js
@@ -5,6 +5,7 @@ module.exports = Object.freeze({
     ...require('./User/deleteUserService/deleteUserService'),
     ...require('./User/updateUserService/updateUserService'),
     ...require('./Post/createPostService/createPostService'),
+    ...require('./Post/listAllPostsService/listAllPostsService'),
     ...require('./Post/listPostService/listPostService'),
     ...require('./Post/deletePostService/deletePostService'),
     ...require('./Post/updatePostService/updatePostService')


### PR DESCRIPTION
1. A causa do problema:
A método GET da rota `/posts` não permitia requisições sem a inclusão obrigatória do parâmetro `user_id` na query, retornando mensagem de erro.

2. O porquê a alteração foi feita daquela maneira:
A alteração foi feita para garantir que todos os posts sejam retornados quando nenhum `user_id` específico for fornecido na query, de acordo com o que consta no Swagger, uma vez que o campo `user_id` não é apontado como obrigatório.

3. Como ela soluciona o problema encontrado:
A rota está configurada para aceitar solicitações GET `/posts` mesmo quando o parâmetro `user_id` não está presente na query. Com isso, o código verifica se há um `user_id` na query, caso contrário, todos os posts são retornados.