### PR TITLE
fix: correct  PUT /post update

### DIFF
--- a/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
@@ -12,7 +12,7 @@ const getPostByPostIdRepositories = async ({
 
     const response = await transaction('posts').where({ id: post_id })
 
-    const has_response = Array.isArray(response) && response.length === 0;
+    const has_response = Array.isArray(response) && response.length > 0;
 
     if(!has_response){
         return {

--- a/src/modules/repositories/Post/updatePostRepositories/updatePostRepositories.js
+++ b/src/modules/repositories/Post/updatePostRepositories/updatePostRepositories.js
@@ -19,6 +19,7 @@ const updatePostRepositories = async ({
             post_text
         })
 
+        await commitTransaction({ transaction })
 
     } catch (err) {
         rollbackTransaction({ transaction })


### PR DESCRIPTION
1. A causa do problema:
A ausência de `commitTransaction` e uma condição incorreta em `has_response`.

2. O porquê a alteração foi feita daquela maneira:
Para corrigir o problema de atualização no PUT /posts, adicionando `commitTransaction` ajustando `has_response`.

3. Como ela soluciona o problema encontrado:
 Garante que a atualização ocorra corretamente e que a transação seja confirmada.