### PR TITLE
test/15

### DIFF
--- a/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
+++ b/src/modules/repositories/Post/deletePostRepositories/deletePostRepositories.js
@@ -4,13 +4,13 @@ const {
     rollbackTransaction
 } = require('../../../common/handlers')
 
-const deletePostRepositories = async (
+const deletePostRepositories = async ({
     post_id
-) => {
+}) => {
     const { transaction } = await getTransaction();
 
     try {
-        await transaction('posts').del()
+        await transaction('posts').where({id: post_id}).del()
 
         await commitTransaction({transaction})
         

--- a/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
+++ b/src/modules/repositories/Post/getPostByPostIdRepositories/getPostByPostIdRepositories.js
@@ -1,6 +1,5 @@
 const { 
     client,
-    getTransaction,
 } = require('../../../common/handlers');
 
 
@@ -8,9 +7,8 @@ const {
 const getPostByPostIdRepositories = async ({
     post_id
 } = {}) => {
-    const { transaction } = await getTransaction();
 
-    const response = await transaction('posts').where({ id: post_id })
+    const response = await client('posts').where({ id: post_id })
 
     const has_response = Array.isArray(response) && response.length > 0;
 


### PR DESCRIPTION
1. A causa do problema:
Na função `deletePostRepositories`  o `post_id`  não era desestruturado em sua extração e faltava a cláusula `where` na transaction. Na consulta ao banco de dados, em `getPostByPostIdRepositories`, foi usado `getTransacion` ao invés de `client`.

2. O porquê a alteração foi feita daquela maneira:
A desestruturação do `post_id` permite que seu valor seja passado de maneira correta para busca no banco de dados e a adição da cláusula `where` permite que apenas o post com o id correspondente seja deletado e não de todos os posts como ocorria. A correção  por `client` foi feita em razão de fazermos como consulta buscando o post com o id específico.

3. Como ela soluciona o problema encontrado:
A correção garante que o `deletePostRepositories` exclua o post específico identificado pelo post_id.