### PR TITLE
test/16

### DIFF
--- a/src/modules/handlers/Posts/createPost.js
+++ b/src/modules/handlers/Posts/createPost.js
@@ -16,7 +16,7 @@ const createPostHandler = async(req, res, next) => {
             author_id
         })
 
-        return res.status(httpStatusCodes.OK).send(created_post);
+        return res.status(httpStatusCodes.CREATED).send(created_post);
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }

--- a/src/modules/handlers/Posts/deletePost.js
+++ b/src/modules/handlers/Posts/deletePost.js
@@ -17,7 +17,7 @@ const deletePostHandler = async (req, res, next) => {
             post_id
         })
 
-        return res.status(httpStatusCodes.OK).send({deletedPost})
+        return res.status(httpStatusCodes.NO_CONTENT).send()
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }

--- a/src/modules/handlers/User/createUser.js
+++ b/src/modules/handlers/User/createUser.js
@@ -11,16 +11,13 @@ const createUserHandler = async (req, res, next) => {
             full_name
         } = req.body
 
-        const userCredentials = { user_email, user_password, full_name };
+        const created_user = await createUserService({
+            user_email,
+            user_password,
+            full_name
+        });
 
-        const { user_created_id } = await createUserService(userCredentials);
-
-        const created_user = {
-            id: user_created_id[0],
-            ...userCredentials
-        }
-
-        return res.status(httpStatusCodes.OK).send(created_user);
+        return res.status(httpStatusCodes.CREATED).send(created_user);
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }

--- a/src/modules/handlers/User/deleteUser.js
+++ b/src/modules/handlers/User/deleteUser.js
@@ -11,13 +11,11 @@ const deleteUserHandler = async (req, res, next) => {
             user_id
         } = req.query;
 
-        const {
-            deletedUser
-        } = await deleteUserService({
+        await deleteUserService({
             user_id
         })
 
-        return res.status(httpStatusCodes.OK).send({deletedUser})
+        return res.status(httpStatusCodes.NO_CONTENT).send()
     }catch(error){
         return httpErrorHandler({ req, res, error })
     }


### PR DESCRIPTION
1. A causa do problema:
Os HTTP status codes para as requisições POST e DELETE nas rotas /users e /posts não estavam seguindo o padrão recomendando, pois ambos utilizavam o código 200 (OK).

2. O porquê a alteração foi feita daquela maneira:
A alteração foi realizada para alinhar os códigos de status HTTP com as convenções. O código de status 201 (Created) agora é utilizado para POST, indicando a criação bem-sucedida, enquanto o código 204 (No Content) é usado para DELETE, indicando sucesso sem conteúdo de resposta.

3. Como ela soluciona o problema encontrado:
Ajustar os códigos de status HTTP garante uma resposta mais precisa e padronizada para as operações POST e DELETE, melhorando a conformidade com as convenções RESTful.